### PR TITLE
Make AllowCreationWhenAutomating attribute class level

### DIFF
--- a/Attributes/ParameterGeneration/AllowCreationWhenAutomating.cs
+++ b/Attributes/ParameterGeneration/AllowCreationWhenAutomating.cs
@@ -3,7 +3,7 @@
     using System;
     using CoreUtils;
 
-    [AttributeUsage(AttributeTargets.Parameter)]
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Class)]
     public class AllowCreationWhenAutomating : Attribute
     {
         private string allowReason;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,11 @@ dotnet_csproj:
   version: '{version}'
   package_version: '{version}'
 install:
-  nuget sources add -name CSharpRuleSet -source https://ci.appveyor.com/nuget/csharpruleset-rxwtqx7d05sl
+- ps: nuget sources add -name CSharpRuleSet -source https://ci.appveyor.com/nuget/csharpruleset-rxwtqx7d05sl
+- ps: nuget sources add -name CoreUtils -source https://ci.appveyor.com/nuget/lib-coreutils-r8l5cjkabp8y
 nuget:
-  account_feed: true 
-  project_feed: true 
+  account_feed: false 
+  project_feed: false 
   disable_publish_on_pr: true
 init:
 - ps: if ($env:APPVEYOR_REPO_TAG -eq "true") { Update-AppveyorBuild -Version "$env:APPVEYOR_REPO_TAG_NAME" }


### PR DESCRIPTION
Allows a user to mark an entire class as `AllowCreationWhenAutomating` instead of having to mark every time the class is used as a parameter